### PR TITLE
Default ports for Kafka and stack trace logging in console could be problematic

### DIFF
--- a/quotegame-api/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/quotegame-api/.mvn/wrapper/MavenWrapperDownloader.java
@@ -88,8 +88,7 @@ public class MavenWrapperDownloader {
             System.out.println("Done");
             System.exit(0);
         } catch (Throwable e) {
-            System.out.println("- Error downloading");
-            e.printStackTrace();
+            System.out.println("- Error downloading: "  + e.getMessage() );
             System.exit(1);
         }
     }

--- a/quotegame-api/src/main/resources/application.properties
+++ b/quotegame-api/src/main/resources/application.properties
@@ -12,13 +12,13 @@ quarkus.http.cors=true
 quarkus.infinispan-client.server-list=localhost:11222
 
 # Configure Kafka broker address
-kafka.bootstrap-service=localhost:9092
+kafka.bootstrap-service=localhost:9002
 
 # Define other values when deploying into Kubernetes
 %kube.quarkus.log.level=INFO
 %kube.quarkus.log.console.level=INFO
 %kube.quarkus.infinispan-client.server-list=infinispan:11222
-%kube.kafka.bootstrap-service=my-cluster-kafka-bootstrap:9092
+%kube.kafka.bootstrap-service=my-cluster-kafka-bootstrap:9002
 
 %local.quarkus.infinispan-client.server-list=docker.for.mac.localhost:11222
-%local.kafka.bootstrap-service=docker.for.mac.localhost:9092
+%local.kafka.bootstrap-service=docker.for.mac.localhost:9002

--- a/quotegame-chaosmonkey/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/quotegame-chaosmonkey/.mvn/wrapper/MavenWrapperDownloader.java
@@ -88,8 +88,7 @@ public class MavenWrapperDownloader {
             System.out.println("Done");
             System.exit(0);
         } catch (Throwable e) {
-            System.out.println("- Error downloading");
-            e.printStackTrace();
+            System.out.println("- Error downloading: "  + e.getMessage() );
             System.exit(1);
         }
     }

--- a/quotegame-processors/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/quotegame-processors/.mvn/wrapper/MavenWrapperDownloader.java
@@ -88,8 +88,7 @@ public class MavenWrapperDownloader {
             System.out.println("Done");
             System.exit(0);
         } catch (Throwable e) {
-            System.out.println("- Error downloading");
-            e.printStackTrace();
+            System.out.println("- Error downloading: "  + e.getMessage() );
             System.exit(1);
         }
     }


### PR DESCRIPTION
Details on default ports 

```
Data storage,  MySQL 3306, reff: https://dev.mysql.com/doc/mysql-port-reference/en/mysql-ports-reference-tables.html
Data storage,  Postgres 5432, reff: https://www.postgresql.org/docs/8.3/app-postgres.html 
Data storage,  MongoDB 27017, reff: https://docs.mongodb.com/manual/reference/default-mongodb-port/
Data transfer, rabbitMQ 5672, reff: https://www.rabbitmq.com/networking.html
Data transfer, Kafka 9092, reff: https://kafka.apache.org/07/documentation.html
Data transfer, HTTP, http 80 , 443 , reff: https://geekflare.com/default-port-numbers/  
Data storage,  Zookeeper 2181, reff: https://zookeeper.apache.org/doc/r3.1.2/zookeeperStarted.html
Monitoring,    zipkin 9411    , reff: https://zipkin.io/pages/extensions_choices
```